### PR TITLE
Issue where MB_STRING is already defined

### DIFF
--- a/src/Laravel/Str.php
+++ b/src/Laravel/Str.php
@@ -1,6 +1,9 @@
 <?php namespace Laravel;
 
-define('MB_STRING', (int) function_exists('mb_get_info'));
+if (!defined('MB_STRING'))
+{
+  define('MB_STRING', (int) function_exists('mb_get_info'));
+}
 
 class Str {
 


### PR DESCRIPTION
I just installed Underscore.php into a Laravel 3 project that I'm working on (via Composer) and started getting an unhandled exception stating that MB_STRING was already defined (in laravel/core.php).

I've added a simple conditional to prevent that error from happening. Thanks!
