### PR TITLE
Use a standard version for illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=5.3.0",
-    "illuminate/support": "dev-master"
+    "illuminate/support": "4.0.x"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
Most packages are using `4.0.x`, so using `dev-master` breaks many dependency chains.
