### PR TITLE
Fixed array key contain dot for CollectionMethods.

### DIFF
--- a/src/Underscore/Methods/CollectionMethods.php
+++ b/src/Underscore/Methods/CollectionMethods.php
@@ -42,6 +42,10 @@ abstract class CollectionMethods
   {
     if (is_null($key)) return $collection;
 
+    if (!is_object($collection) && isset($collection[$key])) {
+      return $collection[$key];
+    }
+
     // Crawl through collection, get key according to object or not
     foreach (explode('.', $key) as $segment) {
 


### PR DESCRIPTION
This fixes #10 .

But still not work for array like `array('aaa.bbb' => array('ccc' => 'harry'));`.
Use `ArraysMethods::get($array, 'aaa.bbb.ccc', false);` may still get false.
