### PR TITLE
Arrays::find returns null when not found

### DIFF
--- a/src/Underscore/Methods/ArraysMethods.php
+++ b/src/Underscore/Methods/ArraysMethods.php
@@ -162,7 +162,7 @@ class ArraysMethods extends CollectionMethods
       if ($closure($value, $key)) return $value;
     }
 
-    return $array;
+    return null;
   }
 
   /**

--- a/tests/Types/ArraysTest.php
+++ b/tests/Types/ArraysTest.php
@@ -168,7 +168,7 @@ class ArraysTest extends UnderscoreWrapper
     $unfound = Arrays::find($this->arrayNumbers, function($value) {
       return $value == 5;
     });
-    $this->assertEquals($this->arrayNumbers, $unfound);
+    $this->assertNull($unfound);
   }
 
   public function testCanFilterValuesFromAnArray()


### PR DESCRIPTION
This matches other similar array::find methods (such as underscore.js).
This will fix issue #12
