### PR TITLE
Fix CollectionMethods::get from objects with magic __get methods

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
   backupStaticAttributes="false"
-  bootstrap="vendor/autoload.php"
+  bootstrap="tests/bootstrap.php"
   colors="true"
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"

--- a/src/Underscore/Methods/CollectionMethods.php
+++ b/src/Underscore/Methods/CollectionMethods.php
@@ -51,8 +51,10 @@ abstract class CollectionMethods
 
       // If object
       if (is_object($collection)) {
-        if (!property_exists($collection, $segment)) return $default instanceof Closure ? $default() : $default;
-        else $collection = $collection->$segment;
+        if (!(property_exists($collection, $segment) || method_exists($collection,'__get')))
+          return $default instanceof Closure ? $default() : $default;
+        else
+          $collection = $collection->$segment;
 
       // If array
       } else {

--- a/tests/DispatchTest.php
+++ b/tests/DispatchTest.php
@@ -1,6 +1,4 @@
 <?php
-include '_start.php';
-
 use Underscore\Dispatch;
 
 class DispatchTest extends UnderscoreWrapper

--- a/tests/Types/ObjectTest.php
+++ b/tests/Types/ObjectTest.php
@@ -3,6 +3,16 @@ use Underscore\Types\Object;
 
 class ObjectTest extends UnderscoreWrapper
 {
+  protected $objectMagicMulti;
+
+  public function setUp() {
+    parent::setUp();
+    $this->objectMagicMulti = (object) array(
+      new \fixtures\MagicAccessor($this->arrayMulti[0]),
+      new \fixtures\MagicAccessor($this->arrayMulti[1]),
+      new \fixtures\MagicAccessor($this->arrayMulti[2]),
+    );
+  }
 
   public function testCanCreateObject()
   {
@@ -61,9 +71,11 @@ class ObjectTest extends UnderscoreWrapper
   public function testCanPluckColumns()
   {
     $object = Object::pluck($this->objectMulti, 'foo');
+    $objectMagic = Object::pluck($this->objectMagicMulti, 'foo');
     $matcher = (object) array('bar', 'bar', null);
 
     $this->assertEquals($matcher, $object);
+    $this->assertEquals($matcher, $objectMagic);
   }
 
   public function testCanSetValues()

--- a/tests/_start.php
+++ b/tests/_start.php
@@ -12,6 +12,8 @@ abstract class UnderscoreWrapper extends PHPUnit_Framework_TestCase
     array('bar' => 'foo', 'bis' => 'ter'),
   );
   public $object;
+	/** @var stdClass */
+	protected $objectMulti;
 
   /**
    * Starts the bundle

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+/** @var $al \Composer\Autoload\ClassLoader */
+$al = require_once __DIR__ . '/../vendor/autoload.php';
+$al->add('fixtures', __DIR__);
+
+require __DIR__ . '/_start.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL);
 /** @var $al \Composer\Autoload\ClassLoader */
 $al = require_once __DIR__ . '/../vendor/autoload.php';
 $al->add('fixtures', __DIR__);

--- a/tests/fixtures/MagicAccessor.php
+++ b/tests/fixtures/MagicAccessor.php
@@ -1,0 +1,14 @@
+<?php
+namespace fixtures;
+class MagicAccessor
+{
+  private $values;
+
+  public function __construct(array $values) {
+    $this->values = $values;
+  }
+
+  public function __get($key) {
+    return $this->values[$key];
+  }
+}

--- a/tests/fixtures/MagicAccessor.php
+++ b/tests/fixtures/MagicAccessor.php
@@ -9,6 +9,6 @@ class MagicAccessor
   }
 
   public function __get($key) {
-    return $this->values[$key];
+    return isset($this->values[$key]) ? $this->values[$key] : null;
   }
 }


### PR DESCRIPTION
Problem raise with Yii ActiveRecord and other `__get()`-powered class collections, where `property_exists()` will fail.

Also i have idea to use getter-method as a key (or any method without required params) to pluck like
```php
class Foo{ 
  function someField(){ /* returns something */ }
}

Arrays::from(/* list of Foo instances */)->pluck('someField');
```