### PR TITLE
PHP Doc @return type fix for underscore(..) function

### DIFF
--- a/start.php
+++ b/start.php
@@ -17,7 +17,7 @@ Autoloader::alias('Underscore\Underscore', $alias);
  * Shortcut alias to creating an Underscore object
  *
  * @param array $array An array to wrap
- * @return Underscore
+ * @return \Underscore\Underscore
  */
 function underscore($array)
 {


### PR DESCRIPTION
IDE fails to autocomplete as the @return definition is incorrect. (Tested in PHPStorm)
