### PR TITLE
Get with Magic

### DIFF
--- a/src/Methods/CollectionMethods.php
+++ b/src/Methods/CollectionMethods.php
@@ -51,7 +51,7 @@ abstract class CollectionMethods
 
       // If object
       if (is_object($collection)) {
-        if (!property_exists($collection, $segment)) return $default instanceof Closure ? $default() : $default;
+        if (!isset($collection->{$segment})) return $default instanceof Closure ? $default() : $default;
         else $collection = $collection->$segment;
 
       // If array


### PR DESCRIPTION
After making the change I just noticed that there had been a historic (from Feb) attempt to address this. :)

In any event, hope you can approve this. Magic may have performance costs but who doesn't love magic? To me the one tradeoff is the fact that a property can legitimately have a "null" value but this would be addressed by the default being set to "null" and in fact the object and array are more consistent in behaviour now.
