### PR TITLE
Allows for sensible default filter comparison

### DIFF
--- a/src/Methods/CollectionMethods.php
+++ b/src/Methods/CollectionMethods.php
@@ -139,8 +139,11 @@ abstract class CollectionMethods
    * @param string $comparisonOp
    * @return void
    */
-  public static function filterBy($collection,$property,$value,$comparisonOp="eq")
+  public static function filterBy($collection,$property,$value,$comparisonOp=null)
   {
+	  if(!$comparisonOp) {
+		  $comparisonOp = is_array($value) ? 'contains' : 'eq';
+	  }
       $ops = array(
           'eq' => function ($item,$prop,$value) { return $item[$prop] === $value; },
           'gt' => function ($item,$prop,$value) { return $item[$prop] > $value; },

--- a/tests/Types/ArraysTest.php
+++ b/tests/Types/ArraysTest.php
@@ -569,6 +569,10 @@ class ArraysTest extends UnderscoreTestCase
 	  $b = Arrays::filterBy($a,'name','baz');
 	  $this->assertCount(1,$b);
 	  $this->assertEquals(2365,$b[0]['value']);
+
+	  $b = Arrays::filterBy($a,'name', array('baz'));
+	  $this->assertCount(1,$b);
+	  $this->assertEquals(2365,$b[0]['value']);
 	  
 	  $c = Arrays::filterBy($a,'value',2468);
 	  $this->assertCount(1,$c);


### PR DESCRIPTION
Rather that statically defaulting to 'eq' comparison it looks at type and determines if 'eq' or 'contains' is the better default. 
