### PR TITLE
Min max improvements

### DIFF
--- a/src/Methods/ArraysMethods.php
+++ b/src/Methods/ArraysMethods.php
@@ -137,7 +137,7 @@ class ArraysMethods extends CollectionMethods
             $array = ArraysMethods::each($array, $closure);
         }
 
-		return max($array);
+        return max($array);
     }
 
     /**


### PR DESCRIPTION
Using lineary complexity instead of quicksort's complexity. (n log2(n) )
Usefull for big arrays.
