### PR TITLE
Add `Functions::partial()`

### DIFF
--- a/src/Methods/FunctionsMethods.php
+++ b/src/Methods/FunctionsMethods.php
@@ -171,6 +171,31 @@ class FunctionsMethods
         };
     }
 
+    /**
+     * Prefill function arguments.
+     *
+     * @param Callable $func
+     *
+     * @return Closure
+     * @author Jeremy Ashkenas
+     */
+    public static function partial(callable $func)
+    {
+        $boundArgs = array_slice(func_get_args(), 1);
+
+        return function () use ($boundArgs, $func) {
+            $args = [];
+            $calledArgs = func_get_args();
+            $position = 0;
+
+            for ($i = 0, $len = count($boundArgs); $i < $len; $i++) {
+                $args[] = $boundArgs[$i] === null ? $calledArgs[$position++] : $boundArgs[$i];
+            }
+
+            return call_user_func_array($func, array_merge($args, array_slice($calledArgs, $position)));
+        };
+    }
+
     ////////////////////////////////////////////////////////////////////
     ////////////////////////////// HELPERS /////////////////////////////
     ////////////////////////////////////////////////////////////////////

--- a/tests/Types/FunctionsTest.php
+++ b/tests/Types/FunctionsTest.php
@@ -76,4 +76,14 @@ class FunctionsTest extends UnderscoreTestCase
 
         $this->assertEquals(2, $number);
     }
+
+    public function testCanPartiallyApplyArguments()
+    {
+        $function = Functions::partial(function () {
+            return implode('', func_get_args());
+        }, 2, null, 6);
+
+        $this->assertEquals('246', $function(4));
+        $this->assertEquals('2468', $function(4, 8));
+    }
 }


### PR DESCRIPTION
Adding a handy little method from the original Underscore. Using `null` as the placeholder since constructor functions can't be passed around in PHP like they can in JS and because `null` in PHP function calls usually means "use the default value."