### PR TITLE
fix Types\Arrays::group() to return empty array

### DIFF
--- a/src/Methods/CollectionMethods.php
+++ b/src/Methods/CollectionMethods.php
@@ -285,12 +285,14 @@ abstract class CollectionMethods
         // Iterate over values, group by property/results from closure
         foreach ($collection as $key => $value) {
             $groupKey = is_callable($grouper) ? $grouper($value, $key) : ArraysMethods::get($value, $grouper);
-            $result[$groupKey] = static::get($result, $groupKey);
+            $newValue = static::get($result, $groupKey);
 
             // Add to results
-            if ($saveKeys) {
+            if ($groupKey !== null && $saveKeys) {
+                $result[$groupKey] = $newValue;
                 $result[$groupKey][$key] = $value;
-            } else {
+            } elseif ($groupKey !== null) {
+                $result[$groupKey] = $newValue;
                 $result[$groupKey][] = $value;
             }
         }

--- a/tests/Types/ArraysTest.php
+++ b/tests/Types/ArraysTest.php
@@ -395,6 +395,12 @@ class ArraysTest extends UnderscoreTestCase
         $this->assertEquals($matcher, $under);
     }
 
+    public function testCanGroupValuesWithNonExistingKey()
+    {
+        $this->assertEquals([], Arrays::group(range(1, 5), 'unknown', true));
+        $this->assertEquals([], Arrays::group(range(1, 5), 'unknown', false));
+    }
+
     public function testCanCreateFromRange()
     {
         $range = Arrays::range(5);


### PR DESCRIPTION
Normally, `Types\Arrays::group()` works like this.

~~~php
<?php

require __DIR__ . '/../vendor/autoload.php';

use Underscore\Types\Arrays;

$rows = [
    ['id' => 1, 'category' => 'a'],
    ['id' => 2, 'category' => 'b'],
    ['id' => 3, 'category' => 'a']
];

var_export(Arrays::group($rows, 'category'));
~~~
~~~sh
❯ php src/arrays_group.php
array (
  'a' =>
  array (
    0 =>
    array (
      'id' => 1,
      'category' => 'a',
    ),
    1 =>
    array (
      'id' => 3,
      'category' => 'a',
    ),
  ),
  'b' =>
  array (
    0 =>
    array (
      'id' => 2,
      'category' => 'b',
    ),
  ),
)
~~~

When I specify key that some rows in `$rows` doesn't have corresponded value, `Arrays::group()` returns result like this. It's  hard to predict.
~~~php
print_r(Arrays::group($rows, 'unknown'));
~~~
~~~sh
❯ php src/arrays_group.php
array (
  '' =>
  array (
    '' =>
    array (
      '' =>
      array (
        0 =>
        array (
          'id' => 1,
          'category' => 'a',
        ),
      ),
      0 =>
      array (
        'id' => 2,
        'category' => 'b',
      ),
    ),
    0 =>
    array (
      'id' => 3,
      'category' => 'a',
    ),
  ),
)
~~~

I would like it to return empty array. Because nothing exists for the key `unknown`.
~~~php
print_r(Arrays::group($rows, 'unknown'));
~~~
~~~sh
❯ php src/arrays_group.php
array (
)
~~~