### PR TITLE
make sure needle is converted to string before calling strpos

### DIFF
--- a/src/Methods/StringsMethods.php
+++ b/src/Methods/StringsMethods.php
@@ -180,7 +180,7 @@ class StringsMethods
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && strpos($haystack, $needle) === 0) {
+            if ($needle !== '' && strpos($haystack, (string)$needle) === 0) {
                 return true;
             }
         }

--- a/tests/Types/StringTest.php
+++ b/tests/Types/StringTest.php
@@ -136,6 +136,13 @@ class StringTest extends UnderscoreTestCase
         $this->assertFalse(Strings::startsWith('barfoo', 'foo'));
     }
 
+    public function testCanAssertAStringStartsWithInteger()
+    {
+        $this->assertTrue(Strings::startsWith('123456.something', 123456));
+        $this->assertTrue(Strings::startsWith('123456.something', [123456]));
+        $this->assertFalse(Strings::startsWith('654321.something', 123456));
+    }
+
     public function testCanAssertAStringEndsWith()
     {
         $this->assertTrue(Strings::endsWith('foobar', 'bar'));


### PR DESCRIPTION
I had (a rather edge case) where startsWith was called from an Arrays::each closure like this:

    $string = "12345";

    Arrays::each([
        '1234' => "jey"
    ], function($value, $key) use ($string) {
        if(Strings::startsWith($string, $key)) {
            print_r("match");
        }
    });

this would never match, since the key is automagically converted into an integer and strpos($haystack, INTEGER) will never match.