### PR TITLE
Adds unique method to Arrays

### DIFF
--- a/src/Methods/ArraysMethods.php
+++ b/src/Methods/ArraysMethods.php
@@ -571,8 +571,7 @@ class ArraysMethods extends CollectionMethods
      * */
     public static function unique($array)
     {
-        return array_reduce($array, function($resultArray, $value)
-        {
+        return array_reduce($array, function ($resultArray, $value) {
             if (!static::contains($resultArray, $value)) {
                 array_push($resultArray, $value);
             }

--- a/src/Methods/ArraysMethods.php
+++ b/src/Methods/ArraysMethods.php
@@ -565,4 +565,19 @@ class ArraysMethods extends CollectionMethods
 
         return $array;
     }
+
+    /*
+     *  Return a duplicate free copy of an array
+     * */
+    public static function unique($array)
+    {
+        return array_reduce($array, function($resultArray, $value)
+        {
+            if (!static::contains($resultArray, $value)) {
+                array_push($resultArray, $value);
+            }
+
+            return $resultArray;
+        }, []);
+    }
 }

--- a/tests/Types/ArraysTest.php
+++ b/tests/Types/ArraysTest.php
@@ -697,6 +697,6 @@ class ArraysTest extends UnderscoreTestCase
         $a = [1, 1, 2];
         $result = Arrays::unique($a);
 
-        $this->assertEquals([1,2], $result);
+        $this->assertEquals([1, 2], $result);
     }
 }

--- a/tests/Types/ArraysTest.php
+++ b/tests/Types/ArraysTest.php
@@ -691,4 +691,12 @@ class ArraysTest extends UnderscoreTestCase
         $this->assertContains('ter', array_values(Arrays::removeValue($a, 'bar')));
         $this->assertContains('two', array_values(Arrays::removeValue($a, 'bar')));
     }
+
+    public function testCanGetUniqueArray()
+    {
+        $a = [1, 1, 2];
+        $result = Arrays::unique($a);
+
+        $this->assertEquals([1,2], $result);
+    }
 }


### PR DESCRIPTION
For now it is a very simple function. It uses `Array::contains` for comparison. 

## differences with regular lodash 

- no key for Array of Objects support
- No sorting option

I don't if you consider those crucial for the method? I could very easily implement them, no problem.