### PR TITLE
Implement indexBy() function on Types\Arrays

### DIFF
--- a/src/Methods/CollectionMethods.php
+++ b/src/Methods/CollectionMethods.php
@@ -372,4 +372,27 @@ abstract class CollectionMethods
             unset($collection[$key]);
         }
     }
+
+    /**
+     * Given a list, and an iteratee function that returns
+     * a key for each element in the list (or a property name),
+     * returns an object with an index of each item.
+     * Just like groupBy, but for when you know your keys are unique.
+     *
+     * @param array $array
+     * @param mixed $key
+     * @return array
+     */
+    public static function indexBy(array $array, $key)
+    {
+        $results = [];
+
+        foreach ($array as $a) {
+            if (isset($a[$key])) {
+                $results[$a[$key]] = $a;
+            }
+        }
+
+        return $results;
+    }
 }

--- a/src/Methods/CollectionMethods.php
+++ b/src/Methods/CollectionMethods.php
@@ -381,6 +381,7 @@ abstract class CollectionMethods
      *
      * @param array $array
      * @param mixed $key
+     *
      * @return array
      */
     public static function indexBy(array $array, $key)

--- a/tests/Types/ArraysTest.php
+++ b/tests/Types/ArraysTest.php
@@ -699,4 +699,48 @@ class ArraysTest extends UnderscoreTestCase
 
         $this->assertEquals([1, 2], $result);
     }
+
+    public function testCanIndexBy()
+    {
+        $array = [
+            ['name' => 'moe', 'age' => 40],
+            ['name' => 'larry', 'age' => 50],
+            ['name' => 'curly', 'age' => 60],
+        ];
+
+        $expected = [
+            40 => ['name' => 'moe', 'age' => 40],
+            50 => ['name' => 'larry', 'age' => 50],
+            60 => ['name' => 'curly', 'age' => 60],
+        ];
+
+        $this->assertEquals($expected, Arrays::indexBy($array, 'age'));
+    }
+
+    public function testIndexByReturnSome()
+    {
+        $array = [
+            ['name' => 'moe', 'age' => 40],
+            ['name' => 'larry', 'age' => 50],
+            ['name' => 'curly'],
+        ];
+
+        $expected = [
+            40 => ['name' => 'moe', 'age' => 40],
+            50 => ['name' => 'larry', 'age' => 50],
+        ];
+
+        $this->assertEquals($expected, Arrays::indexBy($array, 'age'));
+    }
+
+    public function testIndexByReturnEmpty()
+    {
+        $array = [
+            ['name' => 'moe', 'age' => 40],
+            ['name' => 'larry', 'age' => 50],
+            ['name' => 'curly'],
+        ];
+
+        $this->assertEquals([], Arrays::indexBy($array, 'vaaaa'));
+    }
 }


### PR DESCRIPTION
rel: https://github.com/Anahkiasen/underscore-php/issues/33

I would like to implement `Types\Arrays::indexBy()` that is implemented in `underscore.js`.
It's `_.indexBy()` work like this:

```
> var stooges = [{name: 'moe', age: 40}, {name: 'larry', age: 50}, {name: 'curly', age: 60}];
undefined
> u.indexBy(stooges, 'age');
{ '40': { name: 'moe', age: 40 },
  '50': { name: 'larry', age: 50 },
  '60': { name: 'curly', age: 60 } }
>
> u.indexBy(stooges, 'hoge');
{ undefined: { name: 'curly', age: 60 } }
```

In case of non-existing key is specified, `underscore.js`'s `_.indexBy()` return last element with key `undefined` (this might not be intentionally).

But it's better not to include in result in PHP.
So,

``` php
$ php -r 'print_r(Arrays::indexOf(..., "hoge");'
Array
(
)
```
