### PR TITLE
If array is empty, should return false

### DIFF
--- a/src/Methods/ArraysMethods.php
+++ b/src/Methods/ArraysMethods.php
@@ -116,7 +116,7 @@ class ArraysMethods extends CollectionMethods
 
         // Check the results
         if (count($array) === 0) {
-            return true;
+            return false;
         }
         $array = array_search(true, $array, false);
 


### PR DESCRIPTION
How can the array possibly match the closure if it is empty? Has to return false.