### PR TITLE
Fixes PHP Fatal error: Cannot use Underscore\Types\String as String

### DIFF
--- a/src/Methods/StringsMethods.php
+++ b/src/Methods/StringsMethods.php
@@ -14,7 +14,7 @@ namespace Underscore\Methods;
 use Doctrine\Common\Inflector\Inflector;
 use Patchwork\Utf8;
 use RuntimeException;
-use Underscore\Types\Strings;
+use Underscore\Types\Strings as BaseString;
 
 /**
  * Methods to manage strings.
@@ -104,7 +104,7 @@ class StringsMethods
      */
     public static function randomStrings($words, $length = 10)
     {
-        return Strings::from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+        return BaseString::from('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
                      ->shuffle()
                      ->split($length)
                      ->slice(0, $words)


### PR DESCRIPTION
Fixes: #96

The error happens in PHP 7.x

E.g.

> PHP Fatal error:  Cannot use Underscore\Types\String as String because 'String' is a special class name in vendor/radic/tmp-underscore-php/src/Methods/StringMethods.php on line 5

Ignore the CI tests, as they're basically broken. My attempt to fix them is in #102.